### PR TITLE
Drop set_backlight from main.cpp for #6

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,11 +8,6 @@ PicoExplorer pico_explorer(buffer);
 int main() {
     pico_explorer.init();
 
-    // set the backlight to a value between 0 and 255
-    // the backlight is driven via PWM and is gamma corrected by our
-    // library to give a gorgeous linear brightness range.
-    pico_explorer.set_backlight(100);
-
     pico_explorer.set_pen(255, 0, 0);
 
     while(true) {


### PR DESCRIPTION
Should fix #6 - drops the erroneous `set_backlight` from the example.