### PR TITLE
CI: Bump ubuntu runner to 24.04.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,6 +55,15 @@ jobs:
       with:
         release: '13.3.Rel1'
 
+    # CMake 4.0 - erroneously introduced into GitHub runners? -
+    # removed support for <3.5 and mbedtls hits this
+    # https://github.com/raspberrypi/pico-sdk/issues/2391
+    # https://github.com/actions/runner-images/issues/11926
+    - name: Setup cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: '3.31.6'
+
     - name: CMake Version
       run: cmake --version
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,22 +80,12 @@ jobs:
 
     - name: Upload .zip
       if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      uses: softprops/action-gh-release@v1
       with:
-        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
-        upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}.zip
-        asset_content_type: application/zip
+        files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
 
     - name: Upload .tar.gz
       if: github.event_name == 'release'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      uses: softprops/action-gh-release@v1
       with:
-        asset_path: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz
-        upload_url: ${{github.event.release.upload_url}}
-        asset_name: ${{env.RELEASE_FILE}}.tar.gz
-        asset_content_type: application/octet-stream
+        files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,20 +31,20 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: project
 
     # Checkout the Pimoroni Pico Libraries
     - name: Checkout Pimoroni Pico Libraries
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: pimoroni/pimoroni-pico
         path: pimoroni-pico
 
     # Checkout the Pico SDK
     - name: Checkout Pico SDK
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: raspberrypi/pico-sdk
         path: pico-sdk
@@ -80,12 +80,12 @@ jobs:
 
     - name: Upload .zip
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.zip
 
     - name: Upload .tar.gz
       if: github.event_name == 'release'
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: ${{runner.workspace}}/build/${{env.RELEASE_FILE}}.tar.gz

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,6 +48,7 @@ jobs:
       with:
         repository: raspberrypi/pico-sdk
         path: pico-sdk
+        ref: '2.1.1'
         submodules: true
 
     # Linux deps

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             name: Linux
             cache-key: linux
             cmake-args: '-DPIMORONI_PICO_PATH=$GITHUB_WORKSPACE/pimoroni-pico -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,6 +57,9 @@ jobs:
       run: |
         sudo apt update && sudo apt install ${{matrix.apt-packages}}
 
+    - name: CMake Version
+      run: cmake --version
+
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,6 @@ jobs:
             name: Linux
             cache-key: linux
             cmake-args: '-DPIMORONI_PICO_PATH=$GITHUB_WORKSPACE/pimoroni-pico -DPICO_SDK_PATH=$GITHUB_WORKSPACE/pico-sdk -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install'
-            apt-packages: clang-tidy gcc-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
 
     runs-on: ${{matrix.os}}
 
@@ -51,11 +50,10 @@ jobs:
         ref: '2.1.1'
         submodules: true
 
-    # Linux deps
-    - name: Install deps
-      if: runner.os == 'Linux'
-      run: |
-        sudo apt update && sudo apt install ${{matrix.apt-packages}}
+    - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
+      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      with:
+        release: '13.3.Rel1'
 
     - name: CMake Version
       run: cmake --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13...3.27)
 
 # Change your executable name to something creative!
 set(NAME pico-boilerplate) # <-- Name your project/executable here!


### PR DESCRIPTION
Deprecation began today and ubuntu-20.04 will be unavailable from 2025-04-15.

Don't use "ubuntu-latest" since CI might quietly break in future.